### PR TITLE
fix: update navigation to use menubar and menuitem for accessiblity

### DIFF
--- a/src/components/event-listing.astro
+++ b/src/components/event-listing.astro
@@ -17,7 +17,10 @@ const formattedTime = formatTime(start) + "–" + formatTime(end)
 <div
   class="tracking-tight leading-tight flex max-w-prose flex-col gap-2 rounded-2xl p-4 transition-all duration-200 bg-stone-50 hover:bg-stone-100"
 >
-  <h2 class="text-center">
+  <h2
+    class="text-center"
+    id={"listing-title-" + event.title.replaceAll(" ", "-")}
+  >
     <a
       class="text-xl font-bold text-slate-800 underline underline-offset-2 hover:cursor-pointer hover:bg-accent"
       href={event.link}>{event.title}</a

--- a/src/components/page-nav.astro
+++ b/src/components/page-nav.astro
@@ -11,10 +11,11 @@ const links = [
 ]
 ---
 
-<nav aria-label="Build Tech Connect" class="mx-auto mb-8 w-max">
+<nav aria-labelledby="menu" class="mx-auto mb-8 w-max">
   <ul
+    id="menu"
     role="menubar"
-    aria-label="Build Tech Connect"
+    aria-label="site navigation"
     class="grid grid-flow-col auto-cols-fr px-1 py-1 border rounded-full bg-white uppercase text-sm tracking-wide"
   >
     {
@@ -23,10 +24,12 @@ const links = [
           role="none"
           class={cn(
             "text-center hover:text-gray-900 p-1 px-4 rounded-full ",
-            link.active ? "bg-stone-100" : "hover:bg-zinc-100"
+            link.active ? "bg-stone-100" : "hover:bg-zinc-100",
           )}
         >
-          <a role="menuitem" href={link.href}>{link.title}</a>
+          <a role="menuitem" href={link.href}>
+            {link.title}
+          </a>
         </li>
       ))
     }

--- a/src/layouts/page.astro
+++ b/src/layouts/page.astro
@@ -61,8 +61,11 @@ import Fonts from "../components/fonts.astro"
   >
     <PageNav />
 
-    <header class="text-center flex flex-col gap-2 px-2">
-      <h1>
+    <header
+      class="text-center flex flex-col gap-2 px-2"
+      aria-labelledby="site-header"
+    >
+      <h1 id="site-header">
         <SiteLogo />
       </h1>
     </header>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -65,10 +65,12 @@ const {
       upcoming event{_allEventsMeta.count > 1 ? "s" : ""}.
     </p>
   </div>
-  <ul role="list" class="flex flex-col gap-4 mt-4">
+  <ul role="list" aria-label="upcoming events" class="flex flex-col gap-4 mt-4">
     {
       allEvents.map((event) => (
-        <li>
+        <li
+          aria-labelledby={"listing-title-" + event.title.replaceAll(" ", "-")}
+        >
           <EventListing event={event} />
         </li>
       ))


### PR DESCRIPTION
## Changes
- Add `menubar` role to `<ul />` on navigation
- Add `role="none"` to `<li />` on nav item to remove it form the tree
- Add `roel="menuitem"` role to `<a />` on nav item
- Make `<a />` tag child of `<li />` since a list can only have `<li />` as its children