### PR TITLE
fix: wrap banner in very small mobile devices

### DIFF
--- a/src/components/site-logo.astro
+++ b/src/components/site-logo.astro
@@ -1,4 +1,6 @@
-<span class="font-bold font-sans text-4xl antialiased text-textFg">
+<div
+  class="flex flex-wrap justify-center font-bold font-sans text-4xl antialiased text-textFg"
+>
   Build<span class="text-sky-600">·</span>Tech<span class="text-sky-600">·</span
   >Connect
-</span>
+</div>

--- a/src/components/site-logo.astro
+++ b/src/components/site-logo.astro
@@ -1,6 +1,4 @@
-<div
-  class="flex flex-wrap justify-center font-bold font-sans text-4xl antialiased text-textFg"
->
+<span class="font-bold font-sans text-2xl sm:text-4xl antialiased text-textFg">
   Build<span class="text-sky-600">·</span>Tech<span class="text-sky-600">·</span
   >Connect
-</div>
+</span>


### PR DESCRIPTION
| Before | After |
| ------ | ----- |
| <img width="440" alt="image" src="https://github.com/user-attachments/assets/59685234-f11b-4982-9d91-c76fa7d6c21a"> | <img width="410" alt="image" src="https://github.com/user-attachments/assets/452e1802-8d19-476d-beca-0e6a329fdac5"> |
|    <img width="989" alt="image" src="https://github.com/user-attachments/assets/5445886a-43ba-4934-ba87-dfeda86aeffa">    |    <img width="730" alt="image" src="https://github.com/user-attachments/assets/8d431cde-1e10-438a-a8df-fb45d6231834">   |
